### PR TITLE
Jackie added keyboard recommendation

### DIFF
--- a/api.test.js
+++ b/api.test.js
@@ -18,3 +18,9 @@ test('Testing recommend endpoint', async () => {
     const message = res.body.recommendation
     expect(message).toBe('Apple')
 })
+
+test('Testing recommend endpoint', async () => {
+    const res = await request.get('/recommend').query({'type':'keyboards'})
+    const message = res.body.recommendation
+    expect(message).toBe('Logitech MX Keys')
+})

--- a/index.js
+++ b/index.js
@@ -95,6 +95,9 @@ app.get('/recommend', (req, res) => {
     case 'vegetables':
       recommendation = 'Carrot';
       break;
+    case 'keyboards':
+      recommendation = 'Logitech MX Keys';
+      break;
     default:
       recommendation = 'Unknown product type';
   }


### PR DESCRIPTION
Added the following to the /recommend endpoint:

 case 'keyboards':
      recommendation = 'Logitech MX Keys';
      break;

Added the following test to api.test.js:

test('Testing recommend endpoint', async () => {
const res = await request.get('/recommend').query ({'type':'keyboards'})

    const message = res.body.recommendation
    expect(message).toBe('Logitech MX Keys')
})
